### PR TITLE
Comments

### DIFF
--- a/src/async/async.js
+++ b/src/async/async.js
@@ -40,6 +40,7 @@ export function async() {
     const self = go => {
       const canGo = lodash.isFunction(go);
       if (self.settled) {
+        // proceed with cached error/result
         if (self.rejected) {
           if (canGo) {
             return go(self.error);
@@ -143,6 +144,8 @@ export function async() {
       }
     }));
   }
+  // Like _.compose, but async. 
+  // Equivalent to caolan/async.waterfall()
   const pipe = tasks => {
     const _tasks = tasks.slice(0);
     const next = (args, go) => {
@@ -180,10 +183,17 @@ export function async() {
           return next(go);
         });
       }
+      // XXX should errors be included in arg #1?
       return go(null, _results);
     };
     return go => next(go);
   };
+
+  //
+  // Gives a synchronous operation an asynchronous signature.
+  // Used to pass synchronous functions to callers that expect
+  // asynchronous signatures.
+  //
   const _async = function () {
     const f = arguments[0];
     const args = arguments.length >= 2 ? __slice.call(arguments, 1) : [];
@@ -203,6 +213,15 @@ export function async() {
     };
     return _fork(later, args);
   };
+
+  //
+  // Asynchronous find operation.
+  //
+  // find attr, prop, array
+  // find array, attr, prop
+  // find attr, obj
+  // find obj, attr
+  //
   const _find$3 = (attr, prop, obj) => {
     let v;
     let _i;
@@ -270,6 +289,8 @@ export function async() {
         // do nothing
     }
   };
+
+  // Duplicate of _find$2
   const _get = (attr, obj) => {
     if (_isFuture(obj)) {
       return _async(_get, attr, obj);
@@ -281,7 +302,7 @@ export function async() {
     }
   };
   Flow.Async = {
-    createBuffer,
+    createBuffer, // XXX rename
     noop: _noop,
     applicate: _applicate,
     isFuture: _isFuture,

--- a/src/data/data.js
+++ b/src/data/data.js
@@ -1,3 +1,24 @@
+//
+// Insane hack to compress large 2D data tables.
+// The basis for doing this is described here:
+// http://www.html5rocks.com/en/tutorials/speed/v8/
+// See Tip #1 "Hidden Classes"
+//
+// Applies to IE as well:
+// http://msdn.microsoft.com/en-us/library/windows/apps/hh781219.aspx#optimize_property_access
+//
+// http://jsperf.com/big-data-matrix/3
+// As of 31 Oct 2014, for a 10000 row, 100 column table in Chrome,
+//   retained memory sizes:
+// raw json: 31,165 KB
+// array of objects: 41,840 KB
+// array of arrays: 14,960 KB
+// array of prototyped instances: 14,840 KB
+//
+// Usage:
+// Foo = Flow.Data.createCompiledPrototype [ 'bar', 'baz', 'qux', ... ]
+// foo = new Foo()
+//
 export function data() {
   const lodash = window._;
   const Flow = window.Flow;
@@ -7,6 +28,8 @@ export function data() {
   const nextPrototypeName = () => `Map${++_prototypeId}`;
   const _prototypeCache = {};
   const createCompiledPrototype = attrs => {
+    // Since the prototype depends only on attribute names,
+    // return a cached prototype, if any.
     let attr;
     let i;
     const proto = _prototypeCache[cacheKey];
@@ -95,6 +118,7 @@ export function data() {
       const _results = [];
       for (_j = 0, _len1 = types.length; _j < _len1; _j++) {
         type = types[_j];
+        // TODO attach to prototype
         label = lodash.uniqueId('__flow_variable_');
         _results.push(schema[label] = createNumericVariable(label));
       }

--- a/src/dataflow/dataflow.js
+++ b/src/dataflow/dataflow.js
@@ -1,6 +1,10 @@
 import { flowPreludeFunction } from '../flowPreludeFunction';
 const flowPrelude = flowPreludeFunction();
 
+//
+// Reactive programming / Dataflow programming wrapper over ko
+//
+
 export function dataflow() {
   const lodash = window._;
   const Flow = window.Flow;
@@ -147,6 +151,9 @@ export function dataflow() {
       console.assert(lodash.isFunction(arrows.dispose, '[arrow] does not have a [dispose] method'));
       return arrows.dispose();
     };
+    //
+    // Combinators
+    //
     const _apply = (sources, func) => func(...lodash.map(sources, source => source()));
     const _act = (...args) => {
       let _i;

--- a/src/flow/flow.js
+++ b/src/flow/flow.js
@@ -1,6 +1,18 @@
 import { h2oApplication } from '../h2oApplication';
 import { flowApplication } from '../flowApplication';
 
+//
+// TODO
+//
+// XXX how does cell output behave when a widget throws an exception?
+// XXX GLM case is failing badly. Investigate. Should catch/handle gracefully.
+//
+// integrate with groc
+// tooltips on celltype flags
+// arrow keys cause page to scroll - disable those behaviors
+// scrollTo() behavior
+//
+
 export function flow() {
   const Flow = window.Flow;
   const ko = window.ko;

--- a/src/flowApplication.js
+++ b/src/flowApplication.js
@@ -8,6 +8,7 @@ export function flowApplication(_, routines) {
   const Flow = window.Flow;
   flowApplicationContext(_);
   const _sandbox = flowSandbox(_, routines(_));
+  // TODO support external renderers
   const _renderers = Flow.renderers(_, _sandbox);
   flowAnalytics(_);
   flowGrowl(_);

--- a/src/flowAutosave.js
+++ b/src/flowAutosave.js
@@ -1,7 +1,10 @@
 export function flowAutosave(_) {
   const Flow = window.Flow;
   const warnOnExit = e => {
+    // message = 'You have unsaved changes to this notebook.'
     const message = 'Warning: you are about to exit Flow.';
+
+    // < IE8 and < FF4
     e = e != null ? e : window.event;
     if (e) {
       e.returnValue = message;

--- a/src/flowBrowser.js
+++ b/src/flowBrowser.js
@@ -45,6 +45,7 @@ export function flowBrowser(_) {
     if (error) {
       return console.debug(error);
     }
+    // XXX sort
     return _docs(lodash.map(notebooks, notebook => createNotebookView(notebook)));
   });
   Flow.Dataflow.link(_.ready, () => {

--- a/src/flowCoffeescript.js
+++ b/src/flowCoffeescript.js
@@ -24,6 +24,8 @@ export function flowCoffeescript(_, guid, sandbox) {
     }
     return false;
   };
+
+  // XXX special-case functions so that bodies are not printed with the raw renderer.
   const render = (input, output) => {
     let cellResult;
     let outputBuffer;

--- a/src/flowGrowl.js
+++ b/src/flowGrowl.js
@@ -1,6 +1,11 @@
 export function flowGrowl(_) {
   const Flow = window.Flow;
   const $ = window.jQuery;
+  // Type should be one of:
+  // undefined = info (blue)
+  // success (green)
+  // warning (orange)
+  // danger (red)
   return Flow.Dataflow.link(_.growl, (message, type) => {
     if (type) {
       return $.bootstrapGrowl(message, { type });

--- a/src/gui/gui.js
+++ b/src/gui/gui.js
@@ -55,6 +55,8 @@ export function gui() {
     self.value = wrapValue(opts.value, opts.value);
     return self;
   };
+
+  // TODO ko supports array valued args for 'checked' - can provide a checkboxes function
   const dropdown = opts => {
     const self = control('dropdown', opts);
     self.options = opts.options || [];

--- a/src/h2oApplicationContext.js
+++ b/src/h2oApplicationContext.js
@@ -73,6 +73,9 @@ export function h2oApplicationContext(_) {
   _.plot = Flow.Dataflow.slot();
   _.grid = Flow.Dataflow.slot();
   _.enumerate = Flow.Dataflow.slot();
+  //
+  // Sparkling-Water
+  //
   _.scalaIntpId = Flow.Dataflow.signal(-1);
   _.requestRDDs = Flow.Dataflow.slot();
   _.requestDataFrames = Flow.Dataflow.slot();

--- a/src/h2oAutoModelInput.js
+++ b/src/h2oAutoModelInput.js
@@ -34,6 +34,7 @@ export function h2oAutoModelInput(_, _go, opts) {
     let frame;
     if (error) {
       // empty
+      // TODO handle properly
     } else {
       _frames((() => {
         let _i;
@@ -58,6 +59,7 @@ export function h2oAutoModelInput(_, _go, opts) {
         let column;
         if (error) {
           // empty
+          // TODO handle properly
         } else {
           _columns((() => {
             let _i;
@@ -72,7 +74,7 @@ export function h2oAutoModelInput(_, _go, opts) {
           })());
           if (opts.column) {
             _column(opts.column);
-            return delete opts.column;
+            return delete opts.column; // HACK
           }
         }
       });

--- a/src/h2oCloudOutput.js
+++ b/src/h2oCloudOutput.js
@@ -4,6 +4,7 @@ export function h2oCloudOutput(_, _go, _cloud) {
   const moment = window.moment;
   const d3 = window.d3;
   let _isHealthy;
+  // TODO Display in .jade
   const _exception = Flow.Dataflow.signal(null);
   const _isLive = Flow.Dataflow.signal(false);
   const _isBusy = Flow.Dataflow.signal(false);
@@ -17,6 +18,8 @@ export function h2oCloudOutput(_, _go, _cloud) {
   const _isLocked = Flow.Dataflow.signal();
   const _nodes = Flow.Dataflow.signals();
   const formatMilliseconds = ms => Flow.Util.fromNow(new Date(new Date().getTime() - ms));
+
+  // precision = 3
   const format3f = d3.format('.3f');
   const _sizes = [
     'B',
@@ -77,6 +80,7 @@ export function h2oCloudOutput(_, _go, _cloud) {
   };
   const avg = (nodes, attrOf) => sum(nodes, attrOf) / nodes.length;
   const _headers = [
+    // [ Caption, show_always? ]
     [
       '&nbsp;',
       true,

--- a/src/h2oExportModelInput.js
+++ b/src/h2oExportModelInput.js
@@ -17,6 +17,7 @@ export function h2oExportModelInput(_, _go, modelKey, path, opt) {
     let model;
     if (error) {
       // empty
+      // TODO handle properly
     } else {
       _models((() => {
         let _i;

--- a/src/h2oFrameOutput.js
+++ b/src/h2oFrameOutput.js
@@ -71,6 +71,7 @@ export function h2oFrameOutput(_, _go, _frame) {
     return _.requestFrameSummarySliceE(_frame.frame_id.name, searchTerm, startIndex, itemCount, (error, frame) => {
       if (error) {
         // empty
+        // TODO
       } else {
         _lastUsedSearchTerm = searchTerm;
         _currentPage(pageIndex);

--- a/src/h2oGridOutput.js
+++ b/src/h2oGridOutput.js
@@ -109,6 +109,7 @@ export function h2oGridOutput(_, _go, _grid) {
       }
       return _results;
     })();
+    // TODO use table origin
     return _.insertAndExecuteCell('cs', `inspect getModels ${flowPrelude.stringify(allKeys)}`);
   };
   const initialize = grid => {

--- a/src/h2oImportFilesInput.js
+++ b/src/h2oImportFilesInput.js
@@ -2,6 +2,9 @@ import { flowPreludeFunction } from './flowPreludeFunction';
 const flowPrelude = flowPreludeFunction();
 
 export function h2oImportFilesInput(_, _go) {
+  //
+  // Search files/directories
+  //
   const lodash = window._;
   const Flow = window.Flow;
   const _specifiedPath = Flow.Dataflow.signal('');
@@ -19,9 +22,14 @@ export function h2oImportFilesInput(_, _go) {
         return _exception(error.stack);
       }
       _exception('');
+      // _go 'confirm', result
       return processImportResult(result);
     });
   };
+
+  //
+  // File selection
+  //
   const _importedFiles = Flow.Dataflow.signals([]);
   const _importedFileCount = Flow.Dataflow.lift(_importedFiles, files => {
     if (files.length) {
@@ -132,7 +140,7 @@ export function h2oImportFilesInput(_, _go) {
   lodash.defer(_go);
   return {
     specifiedPath: _specifiedPath,
-    hasErrorMessage: _hasErrorMessage,
+    hasErrorMessage: _hasErrorMessage, // XXX obsolete
     exception: _exception,
     tryImportFiles,
     listPathHints: lodash.throttle(listPathHints, 100),

--- a/src/h2oImportFilesOutput.js
+++ b/src/h2oImportFilesOutput.js
@@ -8,6 +8,8 @@ export function h2oImportFilesOutput(_, _go, _importResults) {
   const _canParse = _allFrames.length > 0;
   const _title = `${_allFrames.length} / ${_importResults.length} files imported.`;
   const createImportView = result => ({
+    // TODO dels?
+    // TODO fails?
     files: result.files,
     template: 'flow-import-file-output',
   });

--- a/src/h2oInspectsOutput.js
+++ b/src/h2oInspectsOutput.js
@@ -11,6 +11,7 @@ export function h2oInspectsOutput(_, _go, _tables) {
     return {
       label: table.label,
       description: table.metadata.description,
+      // variables: table.variables #XXX unused?
       inspect,
       grid,
       canPlot: table.metadata.plot,

--- a/src/h2oLogFileOutput.js
+++ b/src/h2oLogFileOutput.js
@@ -1,6 +1,7 @@
 export function h2oLogFileOutput(_, _go, _cloud, _nodeIndex, _fileType, _logFile) {
   const lodash = window._;
   const Flow = window.Flow;
+  // TODO Display in .jade
   const _exception = Flow.Dataflow.signal(null);
   const _contents = Flow.Dataflow.signal('');
   const _nodes = Flow.Dataflow.signal([]);

--- a/src/h2oMergeFramesInput.js
+++ b/src/h2oMergeFramesInput.js
@@ -4,6 +4,7 @@ const flowPrelude = flowPreludeFunction();
 export function h2oMergeFramesInput(_, _go) {
   const lodash = window._;
   const Flow = window.Flow;
+  // TODO display in .jade
   const _exception = Flow.Dataflow.signal(null);
   const _destinationKey = Flow.Dataflow.signal(`merged-${Flow.Util.uuid()}`);
   const _frames = Flow.Dataflow.signals([]);

--- a/src/h2oModelsOutput.js
+++ b/src/h2oModelsOutput.js
@@ -98,6 +98,7 @@ export function h2oModelsOutput(_, _go, _models) {
       }
       return _results;
     })();
+    // TODO use table origin
     return _.insertAndExecuteCell('cs', `inspect getModels ${flowPrelude.stringify(allKeys)}`);
   };
   const initialize = models => {

--- a/src/h2oPartialDependenceInput.js
+++ b/src/h2oPartialDependenceInput.js
@@ -4,6 +4,8 @@ const flowPrelude = flowPreludeFunction();
 export function h2oPartialDependenceInput(_, _go) {
   const lodash = window._;
   const Flow = window.Flow;
+
+  // TODO display in .jade
   const _exception = Flow.Dataflow.signal(null);
   const _destinationKey = Flow.Dataflow.signal(`ppd-${Flow.Util.uuid()}`);
   const _frames = Flow.Dataflow.signals([]);
@@ -11,18 +13,33 @@ export function h2oPartialDependenceInput(_, _go) {
   const _selectedModel = Flow.Dataflow.signals(null);
   const _selectedFrame = Flow.Dataflow.signal(null);
   const _nbins = Flow.Dataflow.signal(20);
+
+  //  a conditional check that makes sure that 
+  //  all fields in the form are filled in
+  //  before the button is shown as active
   const _canCompute = Flow.Dataflow.lift(_destinationKey, _selectedFrame, _selectedModel, _nbins, (dk, sf, sm, nb) => dk && sf && sm && nb);
   const _compute = () => {
     if (!_canCompute()) {
       return;
     }
+
+    // parameters are selections from Flow UI
+    // form dropdown menus, text boxes, etc
     const opts = {
       destination_key: _destinationKey(),
       modelId: _selectedModel(),
       frame_id: _selectedFrame(),
       nbins: _nbins(),
     };
+
+    // assemble a string for the h2o Rapids AST
+    // this contains the function to call
+    // along with the options to pass in
     const cs = `buildPartialDependence ${flowPrelude.stringify(opts)}`;
+
+    // insert a cell with the expression `cs` 
+    // into the current Flow notebook
+    // and run the cell
     return _.insertAndExecuteCell('cs', cs);
   };
   _.requestFrames((error, frames) => {
@@ -52,6 +69,7 @@ export function h2oPartialDependenceInput(_, _go) {
       let _i;
       let _len;
       const _results = [];
+      // TODO use models directly
       for (_i = 0, _len = models.length; _i < _len; _i++) {
         model = models[_i];
         _results.push(model.modelId.name);

--- a/src/h2oPartialDependenceOutput.js
+++ b/src/h2oPartialDependenceOutput.js
@@ -21,7 +21,10 @@ export function h2oPartialDependenceOutput(_, _go, _result) {
     }
     return target(vis.element);
   });
+
+  // Hold as many plots as are present in the result.
   const _plots = [];
+  
   const _ref = _result.partial_dependence_data;
   for (i = _i = 0, _len = _ref.length; _i < _len; i = ++_i) {
     data = _ref[i];

--- a/src/h2oPredictInput.js
+++ b/src/h2oPredictInput.js
@@ -108,6 +108,7 @@ export function h2oPredictInput(_, _go, opt) {
         let _i;
         let _len;
         const _results = [];
+        // TODO use models directly
         for (_i = 0, _len = models.length; _i < _len; _i++) {
           model = models[_i];
           _results.push(model.modelId.name);

--- a/src/h2oPredictOutput.js
+++ b/src/h2oPredictOutput.js
@@ -75,7 +75,10 @@ export function h2oPredictOutput(_, _go, prediction) {
       }
     }
   }
-  const inspect = () => _.insertAndExecuteCell('cs', `inspect getPrediction model: ${flowPrelude.stringify(model.name)}, frame: ${flowPrelude.stringify(frame.name)}`);
+  const inspect = () => {
+    // XXX get this from prediction table
+    return _.insertAndExecuteCell('cs', `inspect getPrediction model: ${flowPrelude.stringify(model.name)}, frame: ${flowPrelude.stringify(frame.name)}`);
+  }
   lodash.defer(_go);
   return {
     plots: _plots,

--- a/src/h2oPredictsOutput.js
+++ b/src/h2oPredictsOutput.js
@@ -105,6 +105,19 @@ export function h2oPredictsOutput(_, _go, opts, _predictions) {
   const predict = () => _.insertAndExecuteCell('cs', 'predict');
   const initialize = predictions => {
     _predictionViews(lodash.map(predictions, createPredictionView));
+
+    // TODO handle non-binomial models
+    // warning: sample code is CoffeeScript
+    // rocCurveConfig =
+    //   data: _.inspect 'scores', _predictions
+    //   type: 'line'
+    //   x: 'FPR'
+    //   y: 'TPR'
+    //   color: 'key'
+    // _.plot rocCurveConfig, (error, el) ->
+    //   unless error
+    //     _rocCurve el
+
     return lodash.defer(_go);
   };
   initialize(_predictions);

--- a/src/imputeInput/imputeInput.js
+++ b/src/imputeInput/imputeInput.js
@@ -74,6 +74,7 @@ export function imputeInput() {
       let frame;
       if (error) {
         // empty
+        // TODO handle properly
       } else {
         _frames((() => {
           let _i;
@@ -98,6 +99,7 @@ export function imputeInput() {
           let column;
           if (error) {
             // empty
+            // TODO handle properly
           } else {
             _columns((() => {
               let _i;
@@ -112,7 +114,7 @@ export function imputeInput() {
             })());
             if (opts.column) {
               _column(opts.column);
-              return delete opts.column;
+              return delete opts.column; // HACK
             }
           }
         });

--- a/src/jobOutput/jobOutput.js
+++ b/src/jobOutput/jobOutput.js
@@ -11,6 +11,11 @@ export function jobOutput() {
     running: '#f0ad4e',
   };
   const getJobOutputStatusColor = status => {
+    // CREATED   Job was created
+    // RUNNING   Job is running
+    // CANCELLED Job was cancelled by user
+    // FAILED    Job crashed, error message/exception is available
+    // DONE      Job was successfully finished
     switch (status) {
       case 'DONE':
         return jobOutputStatusColors.done;
@@ -18,6 +23,7 @@ export function jobOutput() {
       case 'RUNNING':
         return jobOutputStatusColors.running;
       default:
+        // 'CANCELLED', 'FAILED'
         return jobOutputStatusColors.failed;
     }
   };
@@ -149,6 +155,7 @@ export function jobOutput() {
         case 'PartialDependence':
           return _.insertAndExecuteCell('cs', `getPartialDependence ${flowPrelude.stringify(_destinationKey)}`);
         case 'Auto Model':
+          // FIXME getGrid() for AutoML is hosed; resort to getGrids() for now.
           return _.insertAndExecuteCell('cs', 'getGrids');
         case 'Void':
           return alert(`This frame was exported to\n${_job.dest.name}`);

--- a/src/knockout/knockout.js
+++ b/src/knockout/knockout.js
@@ -1,3 +1,39 @@
+//
+// Custom Knockout.js binding handlers
+//
+// init:
+//   This will be called when the binding is first applied to an element
+//   Set up any initial state, event handlers, etc. here
+//
+// update:
+//   This will be called once when the binding is first applied to an element,
+//    and again whenever the associated observable changes value.
+//   Update the DOM element based on the supplied values here.
+//
+// Registering a callback on the disposal of an element
+// 
+// To register a function to run when a node is removed, 
+// you can call ko.utils.domNodeDisposal.addDisposeCallback(node, callback). 
+// As an example, suppose you create a custom binding to instantiate a widget. 
+// When the element with the binding is removed, 
+// you may want to call the destroy method of the widget:
+// 
+// ko.bindingHandlers.myWidget = {
+//     init: function(element, valueAccessor) {
+//         var options = ko.unwrap(valueAccessor()),
+//             $el = $(element);
+//  
+//         $el.myWidget(options);
+//  
+//         ko.utils.domNodeDisposal.addDisposeCallback(element, function() {
+//             // This will be called when the element is removed by Knockout or
+//             // if some other part of your code calls ko.removeNode(element)
+//             $el.myWidget("destroy");
+//         });
+//     }
+// };
+//
+
 export function knockout() {
   const lodash = window._;
   const $ = window.jQuery;
@@ -6,7 +42,7 @@ export function knockout() {
   const marked = window.marked;
   if ((typeof window !== 'undefined' && window !== null ? window.ko : void 0) == null) {
     return;
-  }
+  } 
   ko.bindingHandlers.raw = {
     update(element, valueAccessor, allBindings, viewModel, bindingContext) {
       let $element;
@@ -77,6 +113,9 @@ export function knockout() {
     init(element, valueAccessor, allBindings, viewModel, bindingContext) {
       const arg = ko.unwrap(valueAccessor());
       if (arg) {
+        // Bit of a hack. 
+        // Attaches a method to the bound object that returns the cursor position. 
+        // Uses dwieeb/jquery-textrange.
         arg.getCursorPosition = () => $(element).textrange('get', 'position');
       }
     },
@@ -87,6 +126,8 @@ export function knockout() {
       const arg = ko.unwrap(valueAccessor());
       let resize;
       if (arg) {
+        // Bit of a hack.
+        // Attaches a method to the bound object that resizes the element to fit its content.
         arg.autoResize = resize = () => lodash.defer(() => $el.css('height', 'auto').height(element.scrollHeight));
         $el = $(element).on('input', resize);
         resize();
@@ -99,6 +140,8 @@ export function knockout() {
       let $viewport;
       const arg = ko.unwrap(valueAccessor());
       if (arg) {
+        // Bit of a hack.
+        // Attaches a method to the bound object that scrolls the cell into view
         $el = $(element);
         $viewport = $el.closest('.flow-box-notebook');
         arg.scrollIntoView = immediate => {
@@ -108,6 +151,7 @@ export function knockout() {
           const position = $viewport.scrollTop();
           const top = $el.position().top + position;
           const height = $viewport.height();
+          // scroll if element is outside the viewport
           if (top - 20 < position || top + 20 > position + height) {
             if (immediate) {
               return $viewport.scrollTop(top);
@@ -188,7 +232,9 @@ export function knockout() {
   };
   ko.bindingHandlers.codemirror = {
     init(element, valueAccessor, allBindings, viewModel, bindingContext) {
+      // get the code mirror options
       const options = ko.unwrap(valueAccessor());
+      // created editor replaces the textarea on which it was created
       const editor = CodeMirror.fromTextArea(element, options);
       editor.on('change', cm => allBindings().value(cm.getValue()));
       element.editor = editor;

--- a/src/objectBrowser/objectBrowser.js
+++ b/src/objectBrowser/objectBrowser.js
@@ -88,6 +88,7 @@ export function objectBrowser() {
         return type;
     }
   };
+  // TODO slice large arrays
   Flow.objectBrowserElement = (key, object) => {
     const _expansions = Flow.Dataflow.signal(null);
     const _isExpanded = Flow.Dataflow.signal(false);

--- a/src/routines/routines.js
+++ b/src/routines/routines.js
@@ -143,6 +143,7 @@ export function routines() {
     target = new Array(source.length);
     for (i = _i = 0, _len = source.length; _i < _len; i = ++_i) {
       value = source[i];
+      // TODO handle formatting
       target[i] = value === 'NaN' ? void 0 : value === 'Infinity' ? Number.POSITIVE_INFINITY : value === '-Infinity' ? Number.NEGATIVE_INFINITY : value;
     }
     return target;
@@ -167,6 +168,7 @@ export function routines() {
     }
   };
   convertTableToFrame = (table, tableName, metadata) => {
+    // TODO handle format strings and description
     let column;
     let i;
     let vectors;
@@ -638,6 +640,8 @@ export function routines() {
     let testNetwork;
     let transformBinomialMetrics;
     let unwrapPrediction;
+
+    // TODO move these into Flow.Async
     let _apply;
     let _async;
     let _call;
@@ -671,7 +675,10 @@ export function routines() {
     _isFuture = Flow.Async.isFuture;
     _async = Flow.Async.async;
     _get = Flow.Async.get;
+
+    // XXX obsolete
     proceed = (func, args, go) => go(null, render_({}, () => func(...[_].concat(args || []))));
+
     proceed = (func, args, go) => go(null, render_(...[
             {},
       func
@@ -687,15 +694,19 @@ export function routines() {
       }
     }
     flow_ = raw => raw._flow_ || (raw._flow_ = { _cache_: {} });
+
+    // XXX obsolete
     render_ = (raw, render) => {
       flow_(raw).render = render;
       return raw;
     };
+
     render_ = function () {
       let args;
       let raw;
       let render;
       raw = arguments[0], render = arguments[1], args = arguments.length >= 3 ? __slice.call(arguments, 2) : [];
+      // Prepend current context (_) and a continuation (go)
       flow_(raw).render = go => render(...[
         _,
         go
@@ -853,7 +864,7 @@ export function routines() {
         scores.columns.push({
           name: 'CM',
           description: 'CM',
-          format: 'matrix',
+          format: 'matrix', // TODO HACK
           type: 'matrix'
         });
         scores.data.push(cms);
@@ -1048,7 +1059,7 @@ export function routines() {
         return _results;
       })();
       return createDataframe('parameters', vectors, lodash.range(parameters.length), null, {
-        description: `Parameters for model \'${model.modelId.name}\'`,
+        description: `Parameters for model \'${model.modelId.name}\'`, // TODO frame model_id
         origin: `getModel ${flowPrelude.stringify(model.modelId.name)}`
       });
     };
@@ -1233,6 +1244,8 @@ export function routines() {
         inspections.parameters = inspectModelParameters(model);
         origin = `getModel ${flowPrelude.stringify(model.modelId.name)}`;
         inspectObject(inspections, 'output', origin, model.output);
+
+        // Obviously, an array of 2d tables calls for a megahack.
         if (model.__meta.schema_type === 'NaiveBayesModel') {
           if (lodash.isArray(model.output.pcond)) {
             _ref1 = model.output.pcond;
@@ -1289,6 +1302,14 @@ export function routines() {
       if (algos.length === 1) {
         inspections.parameters = inspectParametersAcrossModels(models);
       }
+
+      // modelCategories = unique (model.output.model_category for model in models)
+      //
+      // TODO implement model comparision after 2d table cleanup for model metrics
+      //
+      // if modelCategories.length is 1
+      //  inspections.outputs = inspectOutputsAcrossModels (head modelCategories), models
+
       inspect_(models, inspections);
       return render_(models, h2oModelsOutput, models);
     };
@@ -1365,6 +1386,7 @@ export function routines() {
         }
       };
       vectors = (() => {
+        // XXX format functions
         let _i;
         let _len;
         let _ref1;
@@ -1680,6 +1702,8 @@ export function routines() {
           intervalData = new Array(binCount);
           widthData = new Array(binCount);
           countData = new Array(binCount);
+
+          // Trim off empty bins from the end
           for (i = _i = 0; binCount >= 0 ? _i < binCount : _i > binCount; i = binCount >= 0 ? ++_i : --_i) {
             m = i * width;
             n = m + width;
@@ -1848,9 +1872,11 @@ export function routines() {
       switch (column.type) {
         case 'int':
         case 'real':
+          // Skip for columns with all NAs
           if (column.histogram_bins.length) {
             inspections.distribution = inspectDistribution;
           }
+          // Skip for columns with all NAs
           if (!lodash.some(column.percentiles, a => a === 'NaN')) {
             inspections.summary = inspectSummary;
             inspections.percentiles = inspectPercentiles;
@@ -2069,10 +2095,16 @@ export function routines() {
       }
       return assist(mergeFrames);
     };
+
+    // define the function that is called when 
+    // the Partial Dependence plot input form
+    // is submitted
     buildPartialDependence = opts => {
       if (opts) {
         return _fork(requestPartialDependence, opts);
       }
+      // specify function to call if user
+      // provides malformed input
       return assist(buildPartialDependence);
     };
     getPartialDependence = destinationKey => {
@@ -2978,11 +3010,17 @@ export function routines() {
       }
     });
     routines = {
+      //
+      // fork/join
+      //
       fork: _fork,
       join: _join,
       call: _call,
       apply: _apply,
       isFuture: _isFuture,
+      //
+      // Dataflow
+      //
       signal: Flow.Dataflow.signal,
       signals: Flow.Dataflow.signals,
       isSignal: Flow.Dataflow.isSignal,
@@ -2990,14 +3028,29 @@ export function routines() {
       react: Flow.Dataflow.react,
       lift: Flow.Dataflow.lift,
       merge: Flow.Dataflow.merge,
+      //
+      // Generic
+      //
       dump,
       inspect,
       plot,
       grid,
       get: _get,
+      //
+      // Meta
+      //
       assist,
+      //
+      // GUI
+      //
       gui,
+      //
+      // Util
+      //
       loadScript,
+      //
+      // H2O
+      //
       getJobs,
       getJob,
       cancelJob,


### PR DESCRIPTION
This PR ports comments from the `h2o-flow` source code.

The following source files contain the `#` character (which CoffeeScript uses to denote a comment) and so were manually reviewed for comments.

```
		"flow.coffee",
		"browser.coffee",
		"cell.coffee",
		"clipboard.coffee",
		"coffeescript.coffee",
		"heading.coffee",
		"help.coffee",
		"notebook.coffee",
		"object-browser.coffee",
		"status.coffee",
		"analytics.coffee",
		"application.coffee",
		"async.coffee",
		"autosave.coffee",
		"coffeescript-kernel.coffee",
		"data.coffee",
		"dataflow.coffee",
		"dialogs.coffee",
		"format.coffee",
		"growl.coffee",
		"gui.coffee",
		"knockout.coffee",
		"local-storage.coffee",
		"util.coffee",
		"assist.coffee",
		"automodel-input.coffee",
		"bind-frames-output.coffee",
		"cloud-output.coffee",
		"column-summary-output.coffee",
		"create-frame-input.coffee",
		"export-frame-input.coffee",
		"export-model-input.coffee",
		"frame-data-output.coffee",
		"frame-output.coffee",
		"frames-output.coffee",
		"grid-output.coffee",
		"grids-output.coffee",
		"import-files-input.coffee",
		"import-files-output.coffee",
		"import-model-input.coffee",
		"import-model-output.coffee",
		"impute-input.coffee",
		"inspect-output.coffee",
		"inspects-output.coffee",
		"job-output.coffee",
		"jobs-output.coffee",
		"log-file-output.coffee",
		"merge-frames-input.coffee",
		"merge-frames-output.coffee",
		"model-input.coffee",
		"model-output.coffee",
		"models-output.coffee",
		"parse-input.coffee",
		"partial-dependence-input.coffee",
		"partial-dependence-output.coffee",
		"plot-input.coffee",
		"predict-input.coffee",
		"predict-output.coffee",
		"predicts-output.coffee",
		"profile-output.coffee",
		"split-frame-input.coffee",
		"split-frame-output.coffee",
		"timeline-output.coffee",
		"application-context.coffee",
		"proxy.coffee",
		"routines.coffee",
		"headless-test.coffee"
```